### PR TITLE
Add the ability to add computers to an account.

### DIFF
--- a/src/boinchub/core/xmlrpc.py
+++ b/src/boinchub/core/xmlrpc.py
@@ -6,6 +6,7 @@
 import fractions
 
 from typing import Annotated
+from uuid import UUID
 
 from pydantic import PlainSerializer
 from pydantic_xml import BaseXmlModel, element, wrapped
@@ -188,6 +189,7 @@ class AccountManagerReply(BaseXmlModel, tag="acct_mgr_reply", search_mode="unord
     host_venue: str | None = element(default=None)
     accounts: list[Account] = element(default_factory=list)
     global_preferences: GlobalPreferences | None = element(default=None)
+    uuid: UUID | None = wrapped("opaque", element(default=None), default=None)
 
 
 class AccountManagerRequest(BaseXmlModel, tag="acct_mgr_request", search_mode="unordered"):
@@ -200,10 +202,11 @@ class AccountManagerRequest(BaseXmlModel, tag="acct_mgr_request", search_mode="u
     client_version: str = element()
     run_mode: str = element()
     platform_name: str = element()
-    previous_host_cpid: str = element()
+    previous_host_cpid: str | None = element(default=None)
+    uuid: UUID | None = wrapped("opaque", element(default=None))
     projects: list[Project] = element(default_factory=list)
     working_global_preferences: GlobalPreferences = wrapped("working_global_preferences", element())
-    global_preferences: GlobalPreferences = element()
+    global_preferences: GlobalPreferences | None = element(default=None)
     host_info: HostInfo = element()
     time_stats: TimeStats = element()
     net_stats: NetStats = element()

--- a/src/boinchub/models/computer.py
+++ b/src/boinchub/models/computer.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2025-present Jason Lynch <jason@aexoden.com>
+#
+# SPDX-License-Identifier: MIT
+"""Computer model for BoincHub."""
+
+import datetime
+import uuid
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, UniqueConstraint, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from boinchub.core.database import Base
+
+if TYPE_CHECKING:
+    from boinchub.models.user import User
+
+
+class Computer(Base):
+    """Computer model for BoincHub."""
+
+    __tablename__ = "computers"
+    __table_args__ = (UniqueConstraint("user_id", "cpid"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, init=False)
+    uuid: Mapped[UUID] = mapped_column(default=uuid.uuid4, unique=True, init=False)
+    cpid: Mapped[str]
+    domain_name: Mapped[str]
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), init=False
+    )
+    last_seen_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), init=False
+    )
+
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user: Mapped["User"] = relationship(back_populates="computers")

--- a/src/boinchub/models/user.py
+++ b/src/boinchub/models/user.py
@@ -5,10 +5,15 @@
 
 import datetime
 
+from typing import TYPE_CHECKING
+
 from sqlalchemy import DateTime, func
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from boinchub.core.database import Base
+
+if TYPE_CHECKING:
+    from boinchub.models.computer import Computer
 
 
 class User(Base):
@@ -23,4 +28,8 @@ class User(Base):
     email: Mapped[str]
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), init=False
+    )
+
+    computers: Mapped[list["Computer"]] = relationship(
+        default_factory=list, back_populates="user", cascade="all, delete-orphan"
     )

--- a/src/boinchub/services/account_service.py
+++ b/src/boinchub/services/account_service.py
@@ -5,7 +5,8 @@
 
 from sqlalchemy.orm import Session
 
-from boinchub.core.xmlrpc import Account, AccountManagerReply, AccountManagerRequest, BoincError, GlobalPreferences
+from boinchub.core.xmlrpc import AccountManagerReply, AccountManagerRequest, BoincError, GlobalPreferences
+from boinchub.services.computer_service import ComputerService
 from boinchub.services.user_service import UserService
 
 
@@ -49,17 +50,17 @@ class AccountService:
                 error_msg="Invalid password",
             )
 
+        # Create or update computer record.
+        computer = ComputerService.update_or_create_computer(
+            self.db,
+            authenticated_user,
+            request,
+        )
+
         # Return successful response with placeholder data
         return AccountManagerReply(
             repeat_sec=3600,
-            global_preferences=GlobalPreferences(
-                run_if_user_active=True,
-            ),
-            accounts=[
-                Account(
-                    url="https://example.com/boinc",
-                    url_signature="invalid signature",
-                    authenticator="invalid authenticator",
-                )
-            ],
+            global_preferences=GlobalPreferences(),
+            accounts=[],
+            uuid=computer.uuid,
         )

--- a/src/boinchub/services/computer_service.py
+++ b/src/boinchub/services/computer_service.py
@@ -66,7 +66,6 @@ class ComputerService:
 
         db.add(computer)
         db.commit()
-        db.refresh(computer)
 
         return computer
 
@@ -99,7 +98,6 @@ class ComputerService:
                 computer.domain_name = request.domain_name
 
                 db.commit()
-                db.refresh(computer)
 
                 return computer
 
@@ -109,7 +107,6 @@ class ComputerService:
         if computer:
             computer.domain_name = request.domain_name
             db.commit()
-            db.refresh(computer)
             return computer
 
         # Check if there's a previous CPID and to find by that value
@@ -124,7 +121,6 @@ class ComputerService:
                 computer.cpid = request.host_cpid
                 computer.domain_name = request.domain_name
                 db.commit()
-                db.refresh(computer)
                 return computer
 
         # Create a new computer

--- a/src/boinchub/services/computer_service.py
+++ b/src/boinchub/services/computer_service.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: 2025-present Jason Lynch <jason@aexoden.com>
+#
+# SPDX-License-Identifier: MIT
+"""Service for  computer-related operations."""
+
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from boinchub.core.xmlrpc import AccountManagerRequest
+from boinchub.models.computer import Computer
+from boinchub.models.user import User
+
+
+class ComputerService:
+    """Service for computer-related operations."""
+
+    @staticmethod
+    def get_computer_by_cpid(db: Session, cpid: str) -> Computer | None:
+        """Get a computer by its CPID.
+
+        Args:
+            db (Session): The database session.
+            cpid (str): The CPID of the computer.
+
+        Returns:
+            The computer object or None if not found.
+
+        """
+        return db.query(Computer).filter(Computer.cpid == cpid).first()
+
+    @staticmethod
+    def get_computer_by_uuid(db: Session, uuid: UUID) -> Computer | None:
+        """Get a computer by its UUID.
+
+        Args:
+            db (Session): The database session.
+            uuid (str): The UUID of the computer.
+
+        Returns:
+            The computer object or None if not found.
+
+        """
+        return db.query(Computer).filter(Computer.uuid == uuid).first()
+
+    @staticmethod
+    def create_computer(db: Session, user: User, cpid: str, domain_name: str) -> Computer:
+        """Create a new computer.
+
+        Args:
+            db (Session): The database session.
+            user (User): The user associated with the computer.
+            cpid (str): The CPID of the computer.
+            domain_name (str): The domain name of the computer.
+
+        Returns:
+            The created computer object.
+
+        """
+        computer = Computer(
+            cpid=cpid,
+            domain_name=domain_name,
+            user_id=user.id,
+            user=user,
+        )
+
+        db.add(computer)
+        db.commit()
+        db.refresh(computer)
+
+        return computer
+
+    @staticmethod
+    def update_or_create_computer(
+        db: Session,
+        user: User,
+        request: AccountManagerRequest,
+    ) -> Computer:
+        """Update or create a computer.
+
+        Args:
+            db (Session): The database session.
+            user (User): The user associated with the computer.
+            uuid (str): The UUID of the computer.
+            cpid (str): The CPID of the computer.
+            domain_name (str): The domain name of the computer.
+
+        Returns:
+            The updated or created computer object.
+
+        """
+        # Check if we have a UUID and if it belongs to the authenticated user. If it doesn't, we will simply ignore it.
+        if request.uuid:
+            computer = ComputerService.get_computer_by_uuid(db, request.uuid)
+
+            if computer and computer.user_id == user.id:
+                # Update metadata
+                computer.cpid = request.host_cpid
+                computer.domain_name = request.domain_name
+
+                db.commit()
+                db.refresh(computer)
+
+                return computer
+
+        # If there was no UUID or the UUID didn't belong to the authenticated user, we will try the CPID.
+        computer = db.query(Computer).filter(Computer.cpid == request.host_cpid, Computer.user_id == user.id).first()
+
+        if computer:
+            computer.domain_name = request.domain_name
+            db.commit()
+            db.refresh(computer)
+            return computer
+
+        # Check if there's a previous CPID and to find by that value
+        if request.previous_host_cpid:
+            computer = (
+                db.query(Computer)
+                .filter(Computer.cpid == request.previous_host_cpid, Computer.user_id == user.id)
+                .first()
+            )
+
+            if computer:
+                computer.cpid = request.host_cpid
+                computer.domain_name = request.domain_name
+                db.commit()
+                db.refresh(computer)
+                return computer
+
+        # Create a new computer
+        return ComputerService.create_computer(db, user, request.host_cpid, request.domain_name)

--- a/src/boinchub/services/user_service.py
+++ b/src/boinchub/services/user_service.py
@@ -90,7 +90,6 @@ class UserService:
 
         db.add(db_user)
         db.commit()
-        db.refresh(db_user)
 
         return db_user
 

--- a/src/boinchub/services/user_service.py
+++ b/src/boinchub/services/user_service.py
@@ -119,7 +119,7 @@ class UserService:
             The MD5 hashed password required by BOINC protocol.
         """
         # The use of MD5 is mandated by the BOINC protocol.
-        return hashlib.md5(f"{password}_{username.lower()}".encode()).hexdigest()  # noqa: S324
+        return hashlib.md5(f"{password}{username.lower()}".encode()).hexdigest()  # noqa: S324
 
     @staticmethod
     def hash_password(password: str) -> str:


### PR DESCRIPTION
With this update, assuming a user has been manually registered, it is possible for a BOINC client to attach to the account manager. However, there is no functionality beyond that.