### PR TITLE
build: fix Docker build and add Docker build test to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,10 +60,18 @@ jobs:
     name: Docker Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-      - name: Build Docker image
-        run: docker build .
+      - name: Validate build configuration
+        uses: docker/build-push-action@v7
+        with:
+          call: check
+
+      - name: Build
+        uses: docker/build-push-action@v7
+        with:
+          push: false
 
   lint:
     name: Lint and Type Check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,15 @@ jobs:
             devbox "$(jq -r '.packages.uv' devbox.json)" \
             docker "$(grep -oP '(?<=COPY --from=ghcr.io/astral-sh/uv:)[^ @]+' Dockerfile | head -n 1)"
 
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Build Docker image
+        run: docker build .
+
   lint:
     name: Lint and Type Check
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app/frontend
 
 # Copy package files and install dependencies
 COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml ./
-RUN corepack enable && pnpm install --frozen-lockfile
+RUN npm install corepack --global --force && corepack enable && pnpm install --frozen-lockfile
 
 # Copy source files and build
 COPY frontend/ ./


### PR DESCRIPTION
The current CI pipeline does not test that the Docker image actually builds. As a result, the Docker image has actually been unbuildable since the bump to node v25, which no longer includes corepack by default. This pull request aims to add a simple Docker build test to the CI and to fix the bug with the current build process.